### PR TITLE
feat(core): implement Go wrappers for vision models and refactor spaw…

### DIFF
--- a/core/models/vision/blip.go
+++ b/core/models/vision/blip.go
@@ -1,0 +1,69 @@
+package vision
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+)
+
+// BlipResponse represents the output of the BLIP model.
+type BlipResponse struct {
+	Caption string  // generated caption
+	Latency float32 // time taken for inference
+	Prompt  string  // input prompt
+	Image   string  // image path
+}
+
+
+// InvokeBlip runs the BLIP model on the given image with optional prompt.
+// model_path: path to the BLIP model
+// image_path: path to the input image
+// prompt: optional text prompt
+// use_fast: whether to use the fast processor
+// max_length: maximum caption length
+func InvokeBlip(modelPath string, imagePath string, prompt string, useFast bool, legacy bool, maxLength int16) BlipResponse {
+	args := []string{
+		"python/models/vision/blip.py",
+		"--model-path", modelPath,
+		"--image-path", imagePath,
+		"--prompt", prompt,
+		"--max-length", fmt.Sprintf("%d", maxLength),
+	}
+
+	if useFast {
+		args = append(args, "--use-fast")
+	}
+	if !legacy {
+		args = append(args, "--no-legacy")
+	}
+
+	cmd := exec.Command("python3", args...)
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		log.Panicf("Failed to run blip.py: %v\nStderr: %s", err, stderr.String())
+	}
+
+	var response BlipResponse
+	// The python script might return an error object.
+	// We'll try to unmarshal into that first.
+	var errorResponse struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &errorResponse); err == nil && errorResponse.Error != "" {
+		log.Panicf("blip.py returned an error: %s", errorResponse.Error)
+	}
+
+	if err := json.Unmarshal(out.Bytes(), &response); err != nil {
+		log.Panicf("Failed to parse blip.py output: %v\nStdout: %s", err, out.String())
+	}
+
+	return response
+}

--- a/core/models/vision/clip.go
+++ b/core/models/vision/clip.go
@@ -1,0 +1,61 @@
+package vision
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"os/exec"
+)
+
+// ClipResponse represents the output of the CLIP model.
+type ClipResponse struct {
+	Results map[string]float32 `json:"results"`
+	Latency float32            `json:"latency"`
+	Image   string             `json:"image"`
+}
+
+// InvokeClip runs the CLIP model on the given image against a list of text labels.
+func InvokeClip(modelPath string, imagePath string, texts []string, useFast bool, device string) ClipResponse {
+	args := []string{
+		"python/models/vision/clip.py",
+		"--model-path", modelPath,
+		"--image-path", imagePath,
+		"--device", device,
+	}
+
+	if useFast {
+		args = append(args, "--use-fast")
+	}
+
+	// Append the text labels for classification
+	args = append(args, "--texts")
+	args = append(args, texts...)
+
+	cmd := exec.Command("python3", args...)
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		log.Panicf("Failed to run clip.py: %v\nStderr: %s", err, stderr.String())
+	}
+
+	var response ClipResponse
+	// Check for a JSON error object from the script
+	var errorResponse struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &errorResponse); err == nil && errorResponse.Error != "" {
+		log.Panicf("clip.py returned an error: %s", errorResponse.Error)
+	}
+
+	// Parse the successful response
+	if err := json.Unmarshal(out.Bytes(), &response); err != nil {
+		log.Panicf("Failed to parse clip.py output: %v\nStdout: %s", err, out.String())
+	}
+
+	return response
+}

--- a/core/models/vision/cliption.go
+++ b/core/models/vision/cliption.go
@@ -1,0 +1,65 @@
+package vision
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+)
+
+// CLIPtionResponse represents the output of the CLIPtion model.
+type CLIPtionResponse struct {
+	Caption string  `json:"caption"`
+	Latency float32 `json:"latency"`
+	Image   string  `json:"image"`
+}
+
+// InvokeCLIPtion runs the CLIPtion model on the given image.
+func InvokeCLIPtion(modelPath string, imagePath string, useFast bool, beamSearch bool, beamWidth int, bestOf int, temperature float32, device string) CLIPtionResponse {
+	args := []string{
+		"python/models/vision/cliption/cliption.py",
+		"--model-path", modelPath,
+		"--image-path", imagePath,
+		"--device", device,
+	}
+
+	if useFast {
+		args = append(args, "--use-fast")
+	}
+
+	if beamSearch {
+		args = append(args, "--beam-search")
+		args = append(args, "--beam-width", fmt.Sprintf("%d", beamWidth))
+	}
+	args = append(args, "--best-of", fmt.Sprintf("%d", bestOf))
+	args = append(args, "--temperature", fmt.Sprintf("%f", temperature))
+
+	cmd := exec.Command("python3", args...)
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		log.Panicf("Failed to run cliption.py: %v\nStderr: %s", err, stderr.String())
+	}
+
+	var response CLIPtionResponse
+	// Check for a JSON error object from the script
+	var errorResponse struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &errorResponse); err == nil && errorResponse.Error != "" {
+		log.Panicf("cliption.py returned an error: %s", errorResponse.Error)
+	}
+
+	// Parse the successful response
+	if err := json.Unmarshal(out.Bytes(), &response); err != nil {
+		log.Panicf("Failed to parse cliption.py output: %v\nStdout: %s", err, out.String())
+	}
+
+	return response
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"llm-cortex/handlers"
 	"llm-cortex/router"
+	"llm-cortex/utils"
 	"net/http"
 	"strings"
 )
@@ -31,10 +32,7 @@ func main() {
 
 	fmt.Println("Starting server at port 8080")
 	err := http.ListenAndServe(":8080", mux)
-	if err != nil {
-		panic(err)
-	}
-
+	utils.HandleError(err)
 }
 
 func rootHandler(w http.ResponseWriter, r *http.Request) {

--- a/python/models/vision/clip.py
+++ b/python/models/vision/clip.py
@@ -27,7 +27,7 @@ class CLIPPlugin:
         with Image.open(image_path) as img:
             image = img.convert("RGB")
 
-        inputs = self.processor(text=texts, images=image, return_tensors="pt", padding=True).to(self.device, self.dtype)
+        inputs = self.processor(text=texts, images=image, return_tensors="pt", padding=True).to(self.device, self.dtype) # type: ignore
 
         with torch.no_grad():
             outputs = self.model(**inputs)

--- a/python/models/vision/cliption/cliption.py
+++ b/python/models/vision/cliption/cliption.py
@@ -17,7 +17,7 @@ from model import CLIPtionModel
 # ----------------------------
 def load_cliption(model_path: str, device: str = "cpu", dtype=torch.float16, use_fast: bool = True) -> CLIPtionModel:
     print(f"[CLIPtion] Loading processor and model from {model_path}...")
-    clip_model = CLIPModel.from_pretrained("openai/clip-vit-large-patch14", dtype=dtype).to(device)
+    clip_model = CLIPModel.from_pretrained("openai/clip-vit-large-patch14", dtype=dtype).to(device) # type: ignore
     processor = CLIPProcessor.from_pretrained("openai/clip-vit-large-patch14", use_fast=use_fast)
 
     safetensor_file = os.path.join(model_path, "CLIPtion_20241219_fp16.safetensors")
@@ -70,7 +70,7 @@ def main():
         with Image.open(args.image_path) as img:
             image = img.convert("RGB")
 
-        inputs = model.processor(images=image, return_tensors="pt").to(device, dtype)
+        inputs = model.processor(images=image, return_tensors="pt").to(device, dtype) # type: ignore
         image_tensor = inputs["pixel_values"]  # [1, 3, 224, 224]
 
         # Generate caption

--- a/python/models/vision/cliption/model.py
+++ b/python/models/vision/cliption/model.py
@@ -68,7 +68,7 @@ class CLIPtionModel(nn.Module):
         self.clip = clip_model
         self.processor = processor
         self.device = next(clip_model.parameters()).device
-        self.tokenizer = processor.tokenizer
+        self.tokenizer = processor.tokenizer # type: ignore
 
         self.captioner = Captioner(config, vision_embed_dim=1024, vocab_size=self.tokenizer.vocab_size)
         self.text_projection = nn.Linear(768, 768, bias=False)
@@ -117,14 +117,14 @@ class CLIPtionModel(nn.Module):
         features = vision_outputs.last_hidden_state.to(device=device, dtype=images.dtype)
 
         # Global image embeddings from full CLIPModel
-        embeds = self.clip.get_image_features(images)
+        embeds = self.clip.get_image_features(images) # type: ignore
         embeds = embeds.to(device=device, dtype=images.dtype)
         embeds /= embeds.norm(dim=-1, keepdim=True)
 
         return features, embeds
 
     def _batch_generate(self, image_features: torch.Tensor, temperature: float, batch_size: int,
-                        seed: int = None, ramble: bool = False) -> torch.Tensor:
+                        seed: int = None, ramble: bool = False) -> torch.Tensor: # type: ignore
         tokenizer = self.tokenizer
         output_proj = self.output_projection
         token_embedding_ = self.clip.text_model.embeddings.token_embedding
@@ -147,7 +147,7 @@ class CLIPtionModel(nn.Module):
             pos_embeds = pos_embedding_(torch.arange(t, device=sequences.device))
             x = token_embeds + pos_embeds
 
-            mask = self.captioner.causal_mask[:t, :t]
+            mask = self.captioner.causal_mask[:t, :t] # type: ignore
             for layer in self.captioner.layers:
                 x = layer(x, memory, self_attn_mask=mask)
 
@@ -171,4 +171,4 @@ class CLIPtionModel(nn.Module):
         return sequences
 
     def _beam_search(self, image_features, image_embed, device, beam_width=4, ramble=False):
-        return [(0.0, self.tokenizer.decode(self._batch_generate(image_features, 1)[0], skip_special_tokens=True))]
+        return [(0.0, self.tokenizer.decode(self._batch_generate(image_features, 1)[0], skip_special_tokens=True))] # type: ignore

--- a/utils/error.go
+++ b/utils/error.go
@@ -1,0 +1,11 @@
+package utils
+
+import "log"
+
+// HandleError checks if an error is not nil and panics if it is.
+// This is a simple utility for handling critical errors that should stop execution.
+func HandleError(err error) {
+	if err != nil {
+		log.Panicf("A critical error occurred: %v", err)
+	}
+}


### PR DESCRIPTION
…n manager

This commit introduces a major feature enhancement by creating a bridge between the Go application and the Python-based vision models. It also includes a significant refactoring of the shell session management for improved safety and code architecture.

Key changes include:

- **Go Vision Model Wrappers:**
  - Implemented `InvokeBlip`, `InvokeClip`, and `InvokeCLIPtion` functions in Go to execute their corresponding Python scripts.
  - These wrappers use `os/exec` to run the Python scripts as separate processes and parse the resulting JSON output into native Go structs.
  - Exposed all tunable parameters from the Python scripts (e.g., `max_length`, `beam_search`, `use_fast`, `legacy`) in the Go function signatures, giving the orchestrator full control over model inference.

- **Spawn Package Refactoring:**
  - Encapsulated the `sessions` map and `mutex` within the `spawn` package, transforming it into a self-contained, thread-safe state manager.
  - Updated all exported functions (`NewShell`, `SendCommand`, `CloseSession`, etc.) to operate on a `sessionID` string handle, which improves API clarity and prevents race conditions.
  - Refactored `handlers/shell.go` to align with the new, cleaner `spawn` package API.

- **Centralized Error Handling:**
  - Introduced a `utils.HandleError` function for consistent, panic-based handling of critical errors, reducing boilerplate code.
  - Integrated the new error handler in `main.go` and other relevant parts of the Go application.